### PR TITLE
Initial version of a release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,8 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: [golangci, test, docker]
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Create the GitHub Release
@@ -102,6 +104,8 @@ jobs:
     name: Build & Upload Release Binaries
     runs-on: ubuntu-latest
     needs: release
+    permissions:
+      contents: write
     strategy:
       matrix:
         include:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,110 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+      - name: Build
+        run: go build -v ./...
+      - name: Test
+        run: go test -v -shuffle=on -cover ./...
+
+  docker:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate image metadata
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: |
+            ghcr.io/dtcenter/METjson2db
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
+          labels: |
+            org.opencontainers.image.vendor=NOAA's Global Systems Laboratory
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [golangci, test, docker]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create the GitHub Release
+        run: |
+          # Create a new release or update an existing one, with generated notes
+          gh release create "${{ github.ref_name }}" --draft --title "Release ${{ github.ref_name }}" --generate-notes
+
+  upload:
+    name: Build & Upload Release Binaries
+    runs-on: ubuntu-latest
+    needs: release
+    strategy:
+      matrix:
+        include:
+          - GOOS: linux
+            GOARCH: amd64
+            OUT: build/METjson2db-linux-amd64
+          - GOOS: linux
+            GOARCH: arm64
+            OUT: build/METjson2db-linux-arm64
+          - GOOS: darwin
+            GOARCH: arm64
+            OUT: build/METjson2db-darwin-arm64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+      - name: Build binary
+        run: |
+          GOOS=${{ matrix.GOOS }} GOARCH=${{ matrix.GOARCH }} go build -o ${{ matrix.OUT }}
+      - name: Upload release binaries
+        run: |
+          gh release upload "${{ github.ref_name }}" "${{ matrix.OUT }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,23 @@ jobs:
         run: |
           # Create a new release or update an existing one, with generated notes
           gh release create "${{ github.ref_name }}" --draft --title "Release ${{ github.ref_name }}" --generate-notes
+      - name: Add release publishing instructions
+        run: |
+          cat << EOF >> $GITHUB_STEP_SUMMARY
+          ## 🚀 Draft Release Created
+
+          A draft release for version ${{ github.ref_name }} has been created.
+
+          ### How to Review and Publish:
+
+          1. Go to [Releases page](https://github.com/${{ github.repository }}/releases)
+          2. Find the draft release for ${{ github.ref_name }}
+          3. Review the generated release notes and binaries
+          4. Click "Edit" to make any changes if needed
+          5. Click "Publish release" when ready to make it public
+
+          **Direct link**: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}
+          EOF
 
   upload:
     name: Build & Upload Release Binaries


### PR DESCRIPTION
This change adds a new GitHub Actions workflow to create a GitHub release, and upload release binaries to the release page when a tag is created. It uses the GitHub CLI tool `gh` to do so. 

Once a release is created, downstream users should be able to download the correct binary for their system from the releases page.

Closes #21